### PR TITLE
Support Pint 0.20 and Pint 0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = ["WeatherFlow", "UDP", "asynchronous", "local"]
 
 [tool.poetry.dependencies]
 python = "^3.8"
-Pint = "^0.19"
+Pint = ">=0.19"
 PsychroLib = "^2.5.0"
 
 [tool.poetry.group.test.dependencies]

--- a/pyweatherflowudp/const.py
+++ b/pyweatherflowudp/const.py
@@ -12,12 +12,11 @@ units = pint.UnitRegistry(
             r"(?<=[A-Za-z])(?![A-Za-z])(?<![0-9\-][eE])(?<![0-9\-])(?=[0-9\-])",
             "**",
         ),
-        lambda string: string.replace("%", "percent"),
     ],
 )
-units.define(
-    pint.unit.UnitDefinition("percent", "%", (), pint.converters.ScaleConverter(0.01))
-)
+if not hasattr(units, "percent"):
+    units.preprocessors.append(lambda string: string.replace("%", "percent"))
+    units.define("percent = 100 = %")
 units.default_format = "P~"
 
 DEFAULT_HOST = "0.0.0.0"

--- a/pyweatherflowudp/helpers.py
+++ b/pyweatherflowudp/helpers.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, TypeVar, cast
 
-from pint import Quantity
-from pint.unit import Unit
+from pint import Quantity, Unit
 
 DIRECTIONS = [
     "N",


### PR DESCRIPTION
Pint 0.20 removes the (unsupported) `pint.unit` and `pint.converters` packages. Pint 0.21 adds a native `percent` unit.

This PR checks if the percent unit exists, and defines it in a Pint 0.19+0.20-compatible way if it does not.

BTW, in general you shouldn't use `==` version dependencies in a library like this, because it can conflict with downstream users of the library. Only end-user apps should have exact version dependencies.